### PR TITLE
fix(facenet): set face confidence correctly

### DIFF
--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -33,6 +33,7 @@ async function main() {
 
       console.log('image file:',    imageFile)
       console.log('face file:',     faceFile)
+      console.log('confidence:',    face.confidence)
       console.log('bounding box:',  face.rect)
       console.log('landmarks:',     face.facialLandmark)
       console.log('embedding:',     face.embedding)

--- a/src/facenet.ts
+++ b/src/facenet.ts
@@ -82,7 +82,7 @@ export class Facenet implements Alignable, Embeddingable {
     const faceList: Face[] = []
     for (const i in boundingBoxes) {
       const boundingBox = this.squareBox(boundingBoxes[i])
-      const confidence = boundingBox[4]
+      const confidence = boundingBoxes[i][4]
       const marks = xyLandmarks[i]
 
       // boundary out of image


### PR DESCRIPTION
Thanks for this project!

I was playing with it and I noticed the confidence isn't passed correctly. There was a bug where it would try to get the value from the square box, instead of the original bounding box which contains the confidence.